### PR TITLE
Fix serialization issues with the isRelative property in fields

### DIFF
--- a/jpasskit/src/main/java/de/brendamour/jpasskit/PKField.java
+++ b/jpasskit/src/main/java/de/brendamour/jpasskit/PKField.java
@@ -40,7 +40,7 @@ public class PKField implements IPKValidateable {
 
     private PKDateStyle dateStyle;
     private PKDateStyle timeStyle;
-    private boolean isRelative;
+    private Boolean isRelative;
 
     public String getKey() {
         return key;
@@ -114,11 +114,11 @@ public class PKField implements IPKValidateable {
         this.timeStyle = timeStyle;
     }
 
-    public boolean isRelative() {
+    public Boolean getIsRelative() {
         return isRelative;
     }
 
-    public void setRelative(final boolean isRelative) {
+    public void setIsRelative(final Boolean isRelative) {
         this.isRelative = isRelative;
     }
 


### PR DESCRIPTION
There were a couple of issues with the isRelative field:
- It was not serialized with correct name due to the naming of the getters/setters. It now serializes correctly to `isRelative` instead of `relative`
- It needed to be nullable (boolean vs Boolean) - i was having issues with iOS not recognizing it as a valid pass if isRelative was on non date fields. It would fail to open the pass.

http://developer.apple.com/library/ios/#documentation/userexperience/Reference/PassKit_Bundle/Chapters/FieldDictionary.html

Of course, it doesn't seem like setting this property made any difference on the passes that I was generating, seems to be a bug with iOS itself. Changing this allows for valid passes now though.
