### PR TITLE
Close the input stream after reading the P12 file.

### DIFF
--- a/jpasskit/src/main/java/de/brendamour/jpasskit/signing/PKSigningUtil.java
+++ b/jpasskit/src/main/java/de/brendamour/jpasskit/signing/PKSigningUtil.java
@@ -252,6 +252,7 @@ public final class PKSigningUtil {
         InputStream streamOfFile = new FileInputStream(p12File);
 
         keystore.load(streamOfFile, password.toCharArray());
+        IOUtils.closeQuietly(streamOfFile);
         return keystore;
     }
 


### PR DESCRIPTION
The file may remains opened and causes issues after many pass generations on Linux OS
