### PR TITLE
Upgraded the commons-io dependency to 2.4

### DIFF
--- a/jpasskit/pom.xml
+++ b/jpasskit/pom.xml
@@ -84,12 +84,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>1.3.2</version>
-		</dependency>
-
-		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
 			<version>1.7</version>
@@ -134,6 +128,11 @@
 		</dependency>
 
 
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.4</version>
+		</dependency>
 	</dependencies>
 	<repositories>
 		<repository>


### PR DESCRIPTION
The new one is backward compatible on the API level and the tests are still passing.

Leverage: If your project depends on a newer commons-io and jpasskit at the same time, you have to keep messing around with dependency exclusions to keep your classpath in shape. (This was my case at least)
