### PR TITLE
Add JSON serialization notations to avoid serializing Charset type (use ...

### DIFF
--- a/jpasskit/src/main/java/de/brendamour/jpasskit/PKBarcode.java
+++ b/jpasskit/src/main/java/de/brendamour/jpasskit/PKBarcode.java
@@ -20,6 +20,8 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
@@ -33,6 +35,7 @@ public class PKBarcode implements IPKValidateable {
     private String altText;
     private String message;
     // updated as Charset is not serializable
+
     private String messageEncoding;
 
     public String getMessage() {
@@ -51,6 +54,8 @@ public class PKBarcode implements IPKValidateable {
         this.format = format;
     }
 
+    // Ignore this when serializing
+    @JsonIgnore
     public Charset getMessageEncoding() {
         if (StringUtils.isNotEmpty(messageEncoding)) {
             return Charset.forName(messageEncoding);
@@ -59,6 +64,7 @@ public class PKBarcode implements IPKValidateable {
         }
     }
 
+    @JsonProperty("messageEncoding")
     public String getMessageEncodingAsString() {
         return messageEncoding;
     }


### PR DESCRIPTION
Fixes issue where messageEncoding is rendering as messageEncoding: {} rather than messageEncoding: "abc".
