### PR TITLE
Fix code listing for 'Signing and Zipping a Pass'

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ The PKSigningUtil contains all necessary methods to:
 
 
 Example to do it all in one step: 
+
 	PKSigningInformation pkSigningInformation = new  PKSigningInformationUtil().loadSigningInformationFromPKCS12AndIntermediateCertificate(keyStorePath,  keyStorePassword, appleWWDRCA);
 	PKPassTemplateFolder passTemplate = new PKPassTemplateFolder(template_path);
 	PKFileBasedSigningUtil pkSigningUtil = new PKFileBasedSigningUtil();


### PR DESCRIPTION
The code listing was not properly indented. This pull request should fix that. Small change but hope it helps!