### PR TITLE
Use the proper date format

### DIFF
--- a/jpasskit/src/main/java/de/brendamour/jpasskit/signing/PKAbstractSigningUtil.java
+++ b/jpasskit/src/main/java/de/brendamour/jpasskit/signing/PKAbstractSigningUtil.java
@@ -128,7 +128,7 @@ public abstract class PKAbstractSigningUtil implements IPKSigningUtil {
     protected ObjectWriter configureObjectMapper(final ObjectMapper jsonObjectMapper) {
         jsonObjectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         jsonObjectMapper.setDateFormat(new StdDateFormat());
-        jsonObjectMapper.configOverride(Date.class).setFormat(JsonFormat.Value.forPattern("yyyy-MM-dd'T'HH:mm:ssZ"));
+        jsonObjectMapper.configOverride(Date.class).setFormat(JsonFormat.Value.forPattern("yyyy-MM-dd'T'HH:mm:ssXXX"));
 
 
         SimpleFilterProvider filters = new SimpleFilterProvider();


### PR DESCRIPTION
When setting the `relevantDate`, my passes won't work. Error in the console said this:
`Unable to parse relevantDate 2019-09-14T16:00:00+0000 as a date. We expect dates in "W3C date time stamp format", either "Complete date plus hours and minutes" or "Complete date plus hours, minutes and seconds". For example, 1980-05-07T10:30-05:00.`

This date format fixed the problem for me. Possibly cause of #204 and #196 ?