### PR TITLE
Migrate expirationDate and relevantDate to Instant

### DIFF
--- a/jpasskit/pom.xml
+++ b/jpasskit/pom.xml
@@ -161,6 +161,10 @@
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 		</dependency>

--- a/jpasskit/src/main/java/de/brendamour/jpasskit/PKFieldBuilder.java
+++ b/jpasskit/src/main/java/de/brendamour/jpasskit/PKFieldBuilder.java
@@ -15,6 +15,7 @@
  */
 package de.brendamour.jpasskit;
 
+import java.time.Instant;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import java.io.Serializable;
@@ -102,7 +103,13 @@ public class PKFieldBuilder implements IPKValidateable, IPKBuilder<PKField> {
         return this;
     }
 
+    @Deprecated
     public PKFieldBuilder value(Date value) {
+        this.field.value = value;
+        return this;
+    }
+
+    public PKFieldBuilder value(Instant value) {
         this.field.value = value;
         return this;
     }
@@ -229,9 +236,9 @@ public class PKFieldBuilder implements IPKValidateable, IPKBuilder<PKField> {
     }
 
     private void checkValueType(List<String> validationErrors) {
-        if (!(this.field.value instanceof String || isNumeric(this.field.value) || this.field.value instanceof Date)) {
+        if (!(this.field.value instanceof String || isNumeric(this.field.value) || this.field.value instanceof Date || this.field.value instanceof Instant)) {
             validationErrors.add(
-                    "Invalid value type. Allowed: String, Integer, Float, Long, Double, java.util.Date, BigDecimal");
+                    "Invalid value type. Allowed: String, Integer, Float, Long, Double, java.util.Date, Instant, BigDecimal");
         }
     }
 

--- a/jpasskit/src/main/java/de/brendamour/jpasskit/PKPass.java
+++ b/jpasskit/src/main/java/de/brendamour/jpasskit/PKPass.java
@@ -17,6 +17,7 @@ package de.brendamour.jpasskit;
 
 import java.io.Serializable;
 import java.net.URL;
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -76,10 +77,10 @@ public class PKPass implements Cloneable, Serializable {
 
     // Relevance Keys
     protected Long maxDistance;
-    protected Date relevantDate;
+    protected Instant relevantDate;
 
     // Expiration Keys
-    protected Date expirationDate;
+    protected Instant expirationDate;
     protected boolean voided; // The key is optional, default value is false
 
     // Feature added in iOS 9.0. It is not applicable to older iOS
@@ -203,11 +204,11 @@ public class PKPass implements Cloneable, Serializable {
         return associatedApps;
     }
 
-    public Date getRelevantDate() {
+    public Instant getRelevantDate() {
         return relevantDate;
     }
 
-    public Date getExpirationDate() {
+    public Instant getExpirationDate() {
         return expirationDate;
     }
 

--- a/jpasskit/src/main/java/de/brendamour/jpasskit/PKPassBuilder.java
+++ b/jpasskit/src/main/java/de/brendamour/jpasskit/PKPassBuilder.java
@@ -17,6 +17,7 @@ package de.brendamour.jpasskit;
 
 import java.awt.Color;
 import java.net.URL;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -313,13 +314,25 @@ public class PKPassBuilder implements IPKValidateable, IPKBuilder<PKPass> {
         return this;
     }
 
+    @Deprecated
     public PKPassBuilder relevantDate(Date relevantDate) {
-        this.pkPass.relevantDate = relevantDate;
+        this.pkPass.relevantDate = relevantDate.toInstant();
         return this;
     }
 
+    @Deprecated
     public PKPassBuilder expirationDate(Date expirationDate) {
-        this.pkPass.expirationDate = expirationDate;
+        this.pkPass.expirationDate = expirationDate.toInstant();
+        return this;
+    }
+
+    public PKPassBuilder relevantDate(Instant relevantInstant) {
+        this.pkPass.relevantDate = relevantInstant;
+        return this;
+    }
+
+    public PKPassBuilder expirationDate(Instant expirationInstant) {
+        this.pkPass.expirationDate = expirationInstant;
         return this;
     }
 

--- a/jpasskit/src/main/java/de/brendamour/jpasskit/signing/PKAbstractSigningUtil.java
+++ b/jpasskit/src/main/java/de/brendamour/jpasskit/signing/PKAbstractSigningUtil.java
@@ -15,6 +15,7 @@
  */
 package de.brendamour.jpasskit.signing;
 
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.File;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -124,6 +125,7 @@ public abstract class PKAbstractSigningUtil implements IPKSigningUtil {
         jsonObjectMapper.setDateFormat(new StdDateFormat());
         jsonObjectMapper.configOverride(Date.class).setFormat(JsonFormat.Value.forPattern("yyyy-MM-dd'T'HH:mm:ssXXX"));
         jsonObjectMapper.setSerializationInclusion(Include.NON_NULL);
+        jsonObjectMapper.registerModule(new JavaTimeModule());
         return jsonObjectMapper.writer();
     }
 

--- a/jpasskit/src/test/java/de/brendamour/jpasskit/PKPassTest.java
+++ b/jpasskit/src/test/java/de/brendamour/jpasskit/PKPassTest.java
@@ -17,6 +17,7 @@ package de.brendamour.jpasskit;
 
 import static de.brendamour.jpasskit.passes.PKGenericPassTest.SOME;
 import static de.brendamour.jpasskit.passes.PKGenericPassTest.field;
+import java.time.Instant;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -65,7 +66,7 @@ public class PKPassTest {
     private static final String GROUPING_ID = "group-1234";
     private static final Long MAX_DISTANCE = 99999L;
     private static final Map<String, Object> USER_INFO = ImmutableMap.<String, Object> of("name", "John Doe");
-    private static final Date EXPIRATION_DATE = new Date();
+    private static final Instant EXPIRATION_DATE = Instant.now();
 
     private PKPassBuilder builder;
 

--- a/jpasskit/src/test/java/de/brendamour/jpasskit/signing/PKFileBasedSigningUtilTest.java
+++ b/jpasskit/src/test/java/de/brendamour/jpasskit/signing/PKFileBasedSigningUtilTest.java
@@ -25,6 +25,7 @@ import de.brendamour.jpasskit.enums.PKPassPersonalizationField;
 import de.brendamour.jpasskit.personalization.PKPersonalization;
 
 import de.brendamour.jpasskit.personalization.PKPersonalizationBuilder;
+import java.time.Instant;
 import org.apache.commons.io.IOUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -65,7 +66,7 @@ public class PKFileBasedSigningUtilTest {
     public void testFileBasedSigningWithLoadedPass() throws Exception {
         PKPass pass = new ObjectMapper().readValue(new File(getPathFromClasspath("pass.json")), PKPass.class);
         PKPassBuilder passBuilder = PKPass.builder(pass)
-                .relevantDate(new Date())
+                .relevantDate(Instant.now())
                 .userInfo(Collections.<String, Object>singletonMap("name", "John Doe"));
 
         passBuilder.getBarcodeBuilders().get(0)

--- a/jpasskit/src/test/java/de/brendamour/jpasskit/signing/PKInMemorySigningUtilTest.java
+++ b/jpasskit/src/test/java/de/brendamour/jpasskit/signing/PKInMemorySigningUtilTest.java
@@ -21,6 +21,7 @@ import java.io.FileOutputStream;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
@@ -104,8 +105,8 @@ public class PKInMemorySigningUtilTest {
 
     @Test
     public void testJSONCreation() throws Exception {
-        Date expirationDate = Date.from(LocalDate.of(2020, 3, 5).atStartOfDay(ZoneId.of("America/Phoenix"))
-                .toInstant());
+        Instant expirationDate = LocalDate.of(2020, 3, 5).atStartOfDay(ZoneId.of("America/Phoenix"))
+                .toInstant();
         PKPassBuilder passBuilder = PKPass.builder()
                 .barcodeBuilder(
                         PKBarcode.builder()


### PR DESCRIPTION
I keep having some random and strange issues with timezones – eg. sometimes the Passcode appears in GMT even thought the timestamp should be in CEST. I am not sure of the cause, but certainly I don't trust the legacy `java.util.Date`. The codebase is already using the `Instant` internally, so this PR exposes it to the world, so we don't need to go through the legacy and depraceted `java.util.Date`.