### PR TITLE
Fix builder not valid when appLaunchURL is set

### DIFF
--- a/jpasskit/src/main/java/de/brendamour/jpasskit/PKPassBuilder.java
+++ b/jpasskit/src/main/java/de/brendamour/jpasskit/PKPassBuilder.java
@@ -381,7 +381,7 @@ public class PKPassBuilder implements IPKValidateable, IPKBuilder<PKPass> {
     private void checkAssociatedAppIfSet(List<String> validationErrors) {
         // If appLaunchURL key is present, the associatedStoreIdentifiers key must also
         // be present
-        if (this.pkPass.appLaunchURL != null && BuilderUtils.isEmpty(this.pkPass.associatedStoreIdentifiers)) {
+        if (this.pkPass.appLaunchURL != null && BuilderUtils.isEmpty(this.associatedStoreIdentifiers)) {
             validationErrors.add("The appLaunchURL requires associatedStoreIdentifiers to be specified");
         }
     }

--- a/jpasskit/src/test/java/de/brendamour/jpasskit/PKPassTest.java
+++ b/jpasskit/src/test/java/de/brendamour/jpasskit/PKPassTest.java
@@ -27,7 +27,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -67,6 +66,7 @@ public class PKPassTest {
     private static final Long MAX_DISTANCE = 99999L;
     private static final Map<String, Object> USER_INFO = ImmutableMap.<String, Object> of("name", "John Doe");
     private static final Instant EXPIRATION_DATE = Instant.now();
+    private static final long ASSOCIATED_STORE_IDENTIFIER = 1L;
 
     private PKPassBuilder builder;
 
@@ -102,6 +102,15 @@ public class PKPassTest {
                                 .format(PKBarcodeFormat.PKBarcodeFormatCode128)
                                 .build()
                 ));
+    }
+
+    @Test
+    public void test_isValidAfterFillingInAppLaunchURLAndAssociatedStoreIdentifiers() {
+        fillBasicFields();
+        this.builder.appLaunchURL(APP_LAUNCH_URL);
+        this.builder.associatedStoreIdentifier(ASSOCIATED_STORE_IDENTIFIER);
+
+        assertThat(this.builder.isValid()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
The `PKPassBuilder.pkpass.associatedStoreIdentifiers` field is only set when `PKPassBuilder.build()` is called, so to check if the builder is in a valid state it should check the (temporary) `PKPassBuilder.associatedStoreIdentifiers` field.