### PR TITLE
Update dependencies with vulnerable transitive dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
 
 [versions]
-com-eatthepath-pushy = "0.15.2"
+com-eatthepath-pushy = "0.15.3"
 com-fasterxml-jackson-core-jackson-databind = "2.16.1"
 com-fasterxml-jackson-datatype-jackson-datatype-jsr310 = "2.16.1"
 com-google-guava-guava = "33.0.0-jre"
@@ -11,7 +11,7 @@ commons-io-commons-io = "2.15.1"
 org-apache-commons-commons-lang3 = "3.14.0"
 org-apache-logging-log4j-log4j-slf4j-impl = "2.22.1"
 org-assertj-assertj-core = "3.24.2"
-org-bouncycastle-bcpkix-jdk15on = "1.70"
+org-bouncycastle-bcpkix-jdk18on = "1.77"
 org-mockito-mockito-core = "5.8.0"
 org-restlet-jse-org-restlet = "2.4.3"
 org-restlet-jse-org-restlet-ext-simple = "2.4.3"
@@ -30,7 +30,7 @@ commons-io-commons-io = { module = "commons-io:commons-io", version.ref = "commo
 org-apache-commons-commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "org-apache-commons-commons-lang3" }
 org-apache-logging-log4j-log4j-slf4j-impl = { module = "org.apache.logging.log4j:log4j-slf4j-impl", version.ref = "org-apache-logging-log4j-log4j-slf4j-impl" }
 org-assertj-assertj-core = { module = "org.assertj:assertj-core", version.ref = "org-assertj-assertj-core" }
-org-bouncycastle-bcpkix-jdk15on = { module = "org.bouncycastle:bcpkix-jdk15on", version.ref = "org-bouncycastle-bcpkix-jdk15on" }
+org-bouncycastle-bcpkix-jdk18on = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "org-bouncycastle-bcpkix-jdk18on" }
 org-mockito-mockito-core = { module = "org.mockito:mockito-core", version.ref = "org-mockito-mockito-core" }
 org-restlet-jse-org-restlet = { module = "org.restlet.jse:org.restlet", version.ref = "org-restlet-jse-org-restlet" }
 org-restlet-jse-org-restlet-ext-simple = { module = "org.restlet.jse:org.restlet.ext.simple", version.ref = "org-restlet-jse-org-restlet-ext-simple" }

--- a/jpasskit/build.gradle.kts
+++ b/jpasskit/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     api(libs.commons.codec.commons.codec)
     api(libs.commons.io.commons.io)
     api(libs.org.apache.commons.commons.lang3)
-    api(libs.org.bouncycastle.bcpkix.jdk15on)
+    api(libs.org.bouncycastle.bcpkix.jdk18on)
     api(libs.org.slf4j.slf4j.api)
     testImplementation(libs.org.apache.logging.log4j.log4j.slf4j.impl)
     testImplementation(libs.org.assertj.assertj.core)

--- a/jpasskit/pom.xml
+++ b/jpasskit/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <url>https://github.com/drallgood/jpasskit</url>
     <inceptionYear>2012</inceptionYear>
     <description>Java Library for Apple PassBook Web Service API (PARENT POM)</description>
-    
+
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>
@@ -73,7 +73,7 @@
         <current.year>2024</current.year>
         <!-- Dependency versions -->
         <assertj.version>3.25.1</assertj.version>
-        <bouncy-castle.version>1.70</bouncy-castle.version>
+        <bouncy-castle.version>1.77</bouncy-castle.version>
         <commons-codec.version>1.16.0</commons-codec.version>
         <commons-io.version>2.15.1</commons-io.version>
         <commons-lang.version>3.14.0</commons-lang.version>
@@ -154,7 +154,7 @@
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk15on</artifactId>
+                <artifactId>bcpkix-jdk18on</artifactId>
                 <version>${bouncy-castle.version}</version>
             </dependency>
             <dependency>
@@ -254,7 +254,7 @@
             <plugin>
               <groupId>org.codehaus.mojo</groupId>
               <artifactId>build-helper-maven-plugin</artifactId>
-              
+
               <executions>
                 <execution>
                   <id>timestamp-property</id>


### PR DESCRIPTION
For Bouncycastle the [**jdk18on** jars are compiled to work with anything from Java 1.8 up.](https://www.bouncycastle.org/latest_releases.html#:~:text=jdk18on%20jars%20are%20compiled%20to%20work%20with%20anything%20from%20Java%201.8%20up).

The pushy dependency was already up to date in the pom.xml file.