### PR TITLE
fix: relevantDates must be a list of objects

### DIFF
--- a/jpasskit/src/main/java/de/brendamour/jpasskit/PKPass.java
+++ b/jpasskit/src/main/java/de/brendamour/jpasskit/PKPass.java
@@ -18,7 +18,6 @@ package de.brendamour.jpasskit;
 import java.io.Serializable;
 import java.net.URL;
 import java.time.Instant;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -56,7 +55,7 @@ public class PKPass implements Cloneable, Serializable {
 
     protected List<PKBeacon> beacons;
     protected List<PKLocation> locations;
-    protected PKRelevantDates relevantDates;
+    protected List<PKRelevantDate> relevantDates;
 
     protected List<PKBarcode> barcodes;
 
@@ -165,7 +164,7 @@ public class PKPass implements Cloneable, Serializable {
         return locations;
     }
 
-    public PKRelevantDates getRelevantDates() {
+    public List<PKRelevantDate> getRelevantDates() {
         return relevantDates;
     }
 

--- a/jpasskit/src/main/java/de/brendamour/jpasskit/PKPassBuilder.java
+++ b/jpasskit/src/main/java/de/brendamour/jpasskit/PKPassBuilder.java
@@ -51,6 +51,7 @@ public class PKPassBuilder implements IPKValidateable, IPKBuilder<PKPass> {
 
     protected List<PKBeaconBuilder> beacons;
     protected List<PKLocationBuilder> locations;
+    protected List<PKRelevantDateBuilder> relevantDates;
     protected List<PKBarcodeBuilder> barcodes;
     protected List<PWAssociatedAppBuilder> associatedApps;
     protected List<Long> associatedStoreIdentifiers;
@@ -60,6 +61,7 @@ public class PKPassBuilder implements IPKValidateable, IPKBuilder<PKPass> {
         this.pass = PKGenericPass.builder();
         this.beacons = new CopyOnWriteArrayList<>();
         this.locations = new CopyOnWriteArrayList<>();
+        this.relevantDates = new CopyOnWriteArrayList<>();
         this.barcodes = new CopyOnWriteArrayList<>();
         this.associatedApps = new CopyOnWriteArrayList<>();
         this.associatedStoreIdentifiers = new CopyOnWriteArrayList<>();
@@ -115,9 +117,7 @@ public class PKPassBuilder implements IPKValidateable, IPKBuilder<PKPass> {
             }
             this.beacons = BuilderUtils.toBeaconBuilderList(pass.getBeacons());
             this.locations = BuilderUtils.toLocationBuilderList(pass.getLocations());
-            if (pass.relevantDates != null) {
-                this.pkPass.relevantDates = pass.relevantDates.clone();
-            }
+            this.relevantDates = BuilderUtils.toRelevantDateBuilderList(pass.getRelevantDates());
             this.barcodes = BuilderUtils.toBarcodeBuilderList(pass.getBarcodes());
             this.associatedApps = BuilderUtils.toAssociatedAppBuilderList(pass.getAssociatedApps());
             if (pass.getAssociatedStoreIdentifiers() != null) {
@@ -242,13 +242,20 @@ public class PKPassBuilder implements IPKValidateable, IPKBuilder<PKPass> {
         return this;
     }
 
-    public PKPassBuilder relevantDates(PKRelevantDates relevantDates) {
-        this.pkPass.relevantDates = relevantDates;
+    public PKPassBuilder relevantDates(List<PKRelevantDate> relevantDates) {
+        if (relevantDates == null || relevantDates.isEmpty()) {
+            this.relevantDates.clear();
+            return this;
+        }
+        relevantDates.stream().map(PKRelevantDate::builder).forEach(this::relevantDatesBuilder);
         return this;
     }
 
-    public PKPassBuilder relevantDatesBuilder(PKRelevantDatesBuilder relevantDatesBuilder) {
-        return relevantDates(relevantDatesBuilder.build());
+    public PKPassBuilder relevantDatesBuilder(PKRelevantDateBuilder relevantDate) {
+        if (relevantDate != null) {
+            this.relevantDates.add(relevantDate);
+        }
+        return this;
     }
 
     public PKPassBuilder barcodeBuilder(PKBarcodeBuilder barcode) {
@@ -469,6 +476,7 @@ public class PKPassBuilder implements IPKValidateable, IPKBuilder<PKPass> {
         }
         this.pkPass.beacons = BuilderUtils.buildAll(this.beacons);
         this.pkPass.locations = BuilderUtils.buildAll(this.locations);
+        this.pkPass.relevantDates = BuilderUtils.buildAll(this.relevantDates);
         this.pkPass.barcodes = BuilderUtils.buildAll(this.barcodes);
         this.pkPass.associatedApps = BuilderUtils.buildAll(this.associatedApps);
         this.pkPass.associatedStoreIdentifiers = Collections.unmodifiableList(this.associatedStoreIdentifiers);

--- a/jpasskit/src/main/java/de/brendamour/jpasskit/PKRelevantDate.java
+++ b/jpasskit/src/main/java/de/brendamour/jpasskit/PKRelevantDate.java
@@ -21,8 +21,8 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import java.io.Serializable;
 import java.time.Instant;
 
-@JsonDeserialize(builder = PKRelevantDatesBuilder.class)
-public class PKRelevantDates implements Cloneable, Serializable {
+@JsonDeserialize(builder = PKRelevantDateBuilder.class)
+public class PKRelevantDate implements Cloneable, Serializable {
 
     private static final long serialVersionUID = -8742901234567890123L;
 
@@ -30,7 +30,7 @@ public class PKRelevantDates implements Cloneable, Serializable {
     protected Instant endDate;
     protected Instant startDate;
 
-    protected PKRelevantDates() {
+    protected PKRelevantDate() {
     }
 
     /**
@@ -63,11 +63,11 @@ public class PKRelevantDates implements Cloneable, Serializable {
     }
 
     @Override
-    protected PKRelevantDates clone() {
+    protected PKRelevantDate clone() {
         try {
-            return (PKRelevantDates) super.clone();
+            return (PKRelevantDate) super.clone();
         } catch (CloneNotSupportedException ex) {
-            throw new IllegalStateException("Failed to clone PKRelevantDates instance", ex);
+            throw new IllegalStateException("Failed to clone PKRelevantDate instance", ex);
         }
     }
 
@@ -76,11 +76,11 @@ public class PKRelevantDates implements Cloneable, Serializable {
         return ToStringBuilder.reflectionToString(this);
     }
 
-    public static PKRelevantDatesBuilder builder() {
-        return new PKRelevantDatesBuilder();
+    public static PKRelevantDateBuilder builder() {
+        return new PKRelevantDateBuilder();
     }
 
-    public static PKRelevantDatesBuilder builder(PKRelevantDates relevantDates) {
+    public static PKRelevantDateBuilder builder(PKRelevantDate relevantDates) {
         return builder().of(relevantDates);
     }
 }

--- a/jpasskit/src/main/java/de/brendamour/jpasskit/PKRelevantDateBuilder.java
+++ b/jpasskit/src/main/java/de/brendamour/jpasskit/PKRelevantDateBuilder.java
@@ -21,26 +21,26 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.time.Instant;
 
 /**
- * Allows constructing and validating {@link PKRelevantDates} entities.
+ * Allows constructing and validating {@link PKRelevantDate} entities.
  */
 @JsonPOJOBuilder(withPrefix = "")
-public class PKRelevantDatesBuilder implements IPKBuilder<PKRelevantDates> {
+public class PKRelevantDateBuilder implements IPKBuilder<PKRelevantDate> {
 
-    private PKRelevantDates relevantDates;
+    private PKRelevantDate relevantDate;
 
-    protected PKRelevantDatesBuilder() {
-        this.relevantDates = new PKRelevantDates();
+    protected PKRelevantDateBuilder() {
+        this.relevantDate = new PKRelevantDate();
     }
 
     @Override
-    public PKRelevantDatesBuilder of(final PKRelevantDates source) {
+    public PKRelevantDateBuilder of(final PKRelevantDate source) {
         if (source == null) {
             return this;
         }
 
-        this.relevantDates.date = source.date;
-        this.relevantDates.endDate = source.endDate;
-        this.relevantDates.startDate = source.startDate;
+        this.relevantDate.date = source.date;
+        this.relevantDate.endDate = source.endDate;
+        this.relevantDate.startDate = source.startDate;
 
         return this;
     }
@@ -53,8 +53,8 @@ public class PKRelevantDatesBuilder implements IPKBuilder<PKRelevantDates> {
      * @return current builder instance for chaining
      */
     @JsonProperty("date")
-    public PKRelevantDatesBuilder date(Instant date) {
-        this.relevantDates.date = date;
+    public PKRelevantDateBuilder date(Instant date) {
+        this.relevantDate.date = date;
         return this;
     }
 
@@ -66,8 +66,8 @@ public class PKRelevantDatesBuilder implements IPKBuilder<PKRelevantDates> {
      * @return current builder instance for chaining
      */
     @JsonProperty("endDate")
-    public PKRelevantDatesBuilder endDate(Instant endDate) {
-        this.relevantDates.endDate = endDate;
+    public PKRelevantDateBuilder endDate(Instant endDate) {
+        this.relevantDate.endDate = endDate;
         return this;
     }
 
@@ -78,13 +78,13 @@ public class PKRelevantDatesBuilder implements IPKBuilder<PKRelevantDates> {
      * @return current builder instance for chaining
      */
     @JsonProperty("startDate")
-    public PKRelevantDatesBuilder startDate(Instant startDate) {
-        this.relevantDates.startDate = startDate;
+    public PKRelevantDateBuilder startDate(Instant startDate) {
+        this.relevantDate.startDate = startDate;
         return this;
     }
 
     @Override
-    public PKRelevantDates build() {
-        return this.relevantDates;
+    public PKRelevantDate build() {
+        return this.relevantDate;
     }
 }

--- a/jpasskit/src/main/java/de/brendamour/jpasskit/util/BuilderUtils.java
+++ b/jpasskit/src/main/java/de/brendamour/jpasskit/util/BuilderUtils.java
@@ -16,17 +16,7 @@
 package de.brendamour.jpasskit.util;
 
 
-import de.brendamour.jpasskit.IPKBuilder;
-import de.brendamour.jpasskit.PKBarcode;
-import de.brendamour.jpasskit.PKBarcodeBuilder;
-import de.brendamour.jpasskit.PKBeacon;
-import de.brendamour.jpasskit.PKBeaconBuilder;
-import de.brendamour.jpasskit.PKField;
-import de.brendamour.jpasskit.PKFieldBuilder;
-import de.brendamour.jpasskit.PKLocation;
-import de.brendamour.jpasskit.PKLocationBuilder;
-import de.brendamour.jpasskit.PWAssociatedApp;
-import de.brendamour.jpasskit.PWAssociatedAppBuilder;
+import de.brendamour.jpasskit.*;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -65,6 +55,10 @@ public class BuilderUtils {
 
     public static List<PKLocationBuilder> toLocationBuilderList(List<PKLocation> locations) {
         return toBuilderList(locations, PKLocation::builder);
+    }
+
+    public static List<PKRelevantDateBuilder> toRelevantDateBuilderList(List<PKRelevantDate> relevantDates) {
+        return toBuilderList(relevantDates, PKRelevantDate::builder);
     }
 
     public static List<PWAssociatedAppBuilder> toAssociatedAppBuilderList(List<PWAssociatedApp> associatedApps) {

--- a/jpasskit/src/test/java/de/brendamour/jpasskit/PKPassBuilderTest.java
+++ b/jpasskit/src/test/java/de/brendamour/jpasskit/PKPassBuilderTest.java
@@ -16,7 +16,6 @@
 package de.brendamour.jpasskit;
 
 import de.brendamour.jpasskit.enums.PKBarcodeFormat;
-import de.brendamour.jpasskit.enums.PKPassType;
 import de.brendamour.jpasskit.passes.*;
 import de.brendamour.jpasskit.semantics.PKCurrencyAmount;
 import org.testng.Assert;
@@ -152,7 +151,7 @@ public class PKPassBuilderTest {
 
     @Test
     public void testOfWithRelevantDates() {
-        PKRelevantDates relevantDates = PKRelevantDates.builder()
+        PKRelevantDate relevantDates = PKRelevantDate.builder()
             .date(Instant.now())
             .build();
         
@@ -162,7 +161,7 @@ public class PKPassBuilderTest {
             .teamIdentifier("TEAM123")
             .description("Test Pass")
             .organizationName("Test Org")
-            .relevantDates(relevantDates)
+            .relevantDates(List.of(relevantDates))
             .pass(PKGenericPass.builder())
             .build();
         

--- a/jpasskit/src/test/java/de/brendamour/jpasskit/PKPassTest.java
+++ b/jpasskit/src/test/java/de/brendamour/jpasskit/PKPassTest.java
@@ -60,7 +60,7 @@ public class PKPassTest {
     private static final Map<String, Object> USER_INFO = ImmutableMap.<String, Object> of("name", "John Doe");
     private static final Instant EXPIRATION_DATE = Instant.now();
     private static final long ASSOCIATED_STORE_IDENTIFIER = 1L;
-    private static final PKRelevantDates RELEVANT_DATES = PKRelevantDates.builder()
+    private static final PKRelevantDate RELEVANT_DATE = PKRelevantDate.builder()
             .date(Instant.now())
             .startDate(Instant.now().minusSeconds(3600))
             .endDate(Instant.now().plusSeconds(7200))
@@ -143,7 +143,9 @@ public class PKPassTest {
         assertThat(pass.getUserInfo()).isNull();
         assertThat(pass.getExpirationDate()).isNull();
         assertThat(pass.getBarcodes()).isNotNull().isEmpty();
-        assertThat(pass.getRelevantDates()).isNull();
+        assertThat(pass.getBeacons()).isNotNull().isEmpty();
+        assertThat(pass.getLocations()).isNotNull().isEmpty();
+        assertThat(pass.getRelevantDates()).isNotNull().isEmpty();
     }
 
     @Test
@@ -181,15 +183,12 @@ public class PKPassTest {
 
     @Test
     public void test_getRelevantDates() {
-        assertThat(this.builder
-                .relevantDates(RELEVANT_DATES)
-                .build()
-                .getRelevantDates()).isEqualTo(RELEVANT_DATES);
-
-        assertThat(this.builder
-                .relevantDates((PKRelevantDates) null)
-                .build()
-                .getRelevantDates()).isNull();
+        var relevantDates = List.of(RELEVANT_DATE);
+        var result = this.builder
+                .relevantDates(relevantDates)
+                .build();
+        assertThat(result.getRelevantDates()).hasSize(1);
+        assertThat(result.getRelevantDates()).usingRecursiveComparison().isEqualTo(relevantDates);
     }
 
     @Test

--- a/jpasskit/src/test/java/de/brendamour/jpasskit/PKRelevantDateTest.java
+++ b/jpasskit/src/test/java/de/brendamour/jpasskit/PKRelevantDateTest.java
@@ -22,13 +22,13 @@ import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PKRelevantDatesTest {
+public class PKRelevantDateTest {
 
     private static final Instant DATE = Instant.parse("2024-01-15T10:00:00Z");
     private static final Instant START_DATE = Instant.parse("2024-01-10T09:00:00Z");
     private static final Instant END_DATE = Instant.parse("2024-01-20T18:00:00Z");
 
-    private PKRelevantDatesBuilder builder;
+    private PKRelevantDateBuilder builder;
 
     private void fillProperties() {
         builder.date(DATE)
@@ -38,7 +38,7 @@ public class PKRelevantDatesTest {
 
     @BeforeMethod
     public void prepareTest() {
-        builder = PKRelevantDates.builder();
+        builder = PKRelevantDate.builder();
         fillProperties();
     }
 
@@ -52,7 +52,7 @@ public class PKRelevantDatesTest {
 
     @Test
     public void test_getters() {
-        PKRelevantDates relevantDates = builder.build();
+        PKRelevantDate relevantDates = builder.build();
 
         assertThat(relevantDates.getDate()).isEqualTo(DATE);
         assertThat(relevantDates.getStartDate()).isEqualTo(START_DATE);
@@ -61,8 +61,8 @@ public class PKRelevantDatesTest {
 
     @Test
     public void test_clone() {
-        PKRelevantDates relevantDates = builder.build();
-        PKRelevantDates copy = PKRelevantDates.builder(relevantDates).build();
+        PKRelevantDate relevantDates = builder.build();
+        PKRelevantDate copy = PKRelevantDate.builder(relevantDates).build();
 
         assertThat(copy)
                 .isNotSameAs(relevantDates)
@@ -75,7 +75,7 @@ public class PKRelevantDatesTest {
 
     @Test
     public void test_toString() {
-        PKRelevantDates relevantDates = builder.build();
+        PKRelevantDate relevantDates = builder.build();
         assertThat(relevantDates.toString())
                 .contains(DATE.toString())
                 .contains(START_DATE.toString())
@@ -84,7 +84,7 @@ public class PKRelevantDatesTest {
 
     @Test
     public void test_builder_partial() {
-        PKRelevantDates relevantDates = PKRelevantDates.builder()
+        PKRelevantDate relevantDates = PKRelevantDate.builder()
                 .date(DATE)
                 .build();
 
@@ -95,7 +95,7 @@ public class PKRelevantDatesTest {
 
     @Test
     public void test_builder_of_null() {
-        PKRelevantDates relevantDates = PKRelevantDates.builder()
+        PKRelevantDate relevantDates = PKRelevantDate.builder()
                 .of(null)
                 .date(DATE)
                 .build();

--- a/jpasskit/src/test/java/de/brendamour/jpasskit/signing/PKFileBasedSigningUtilTest.java
+++ b/jpasskit/src/test/java/de/brendamour/jpasskit/signing/PKFileBasedSigningUtilTest.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import de.brendamour.jpasskit.PKBarcode;
 import de.brendamour.jpasskit.PKPass;
 import de.brendamour.jpasskit.PKPassBuilder;
-import de.brendamour.jpasskit.PKRelevantDates;
+import de.brendamour.jpasskit.PKRelevantDate;
 import de.brendamour.jpasskit.enums.PKBarcodeFormat;
 import de.brendamour.jpasskit.enums.PKPassPersonalizationField;
 import de.brendamour.jpasskit.personalization.PKPersonalization;
@@ -43,6 +43,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 
 public class PKFileBasedSigningUtilTest {
 
@@ -59,7 +60,7 @@ public class PKFileBasedSigningUtilTest {
 
         PKSigningInformation pkSigningInformation =
                 new PKSigningInformationUtil().loadSigningInformationFromPKCS12AndIntermediateCertificate(
-                KEYSTORE_PATH, KEYSTORE_PASSWORD, APPLE_WWDRCA);
+                        KEYSTORE_PATH, KEYSTORE_PASSWORD, APPLE_WWDRCA);
         PKFileBasedSigningUtil pkSigningUtil = new PKFileBasedSigningUtil();
         pkSigningUtil.signManifestFileAndWriteToDirectory(temporaryPassDir, manifestJSONFile, pkSigningInformation);
     }
@@ -181,14 +182,14 @@ public class PKFileBasedSigningUtilTest {
         Instant startDate = Instant.parse("2025-01-15T09:00:00Z");
         Instant endDate = Instant.parse("2025-01-15T11:00:00Z");
 
-        PKRelevantDates relevantDates = PKRelevantDates.builder()
+        PKRelevantDate relevantDate = PKRelevantDate.builder()
                 .date(date)
                 .startDate(startDate)
                 .endDate(endDate)
                 .build();
 
         PKPassBuilder passBuilder = PKPass.builder()
-                .relevantDates(relevantDates)
+                .relevantDates(List.of(relevantDate))
                 .barcodeBuilder(
                         PKBarcode.builder()
                                 .format(PKBarcodeFormat.PKBarcodeFormatQR)
@@ -205,7 +206,7 @@ public class PKFileBasedSigningUtilTest {
         String json = objectMapper.writeValueAsString(pass);
 
         // Verify the relevantDates object is serialized correctly
-        Assert.assertTrue(json.contains("\"relevantDates\""));
+        Assert.assertTrue(json.contains("\"relevantDates\":[{"));
         Assert.assertTrue(json.contains("\"date\":\"2025-01-15T10:00:00Z\""));
         Assert.assertTrue(json.contains("\"startDate\":\"2025-01-15T09:00:00Z\""));
         Assert.assertTrue(json.contains("\"endDate\":\"2025-01-15T11:00:00Z\""));
@@ -213,9 +214,9 @@ public class PKFileBasedSigningUtilTest {
         // Test deserialization back to object
         PKPass deserializedPass = objectMapper.readValue(json, PKPass.class);
         Assert.assertNotNull(deserializedPass.getRelevantDates());
-        Assert.assertEquals(deserializedPass.getRelevantDates().getDate(), date);
-        Assert.assertEquals(deserializedPass.getRelevantDates().getStartDate(), startDate);
-        Assert.assertEquals(deserializedPass.getRelevantDates().getEndDate(), endDate);
+        Assert.assertEquals(deserializedPass.getRelevantDates().get(0).getDate(), date);
+        Assert.assertEquals(deserializedPass.getRelevantDates().get(0).getStartDate(), startDate);
+        Assert.assertEquals(deserializedPass.getRelevantDates().get(0).getEndDate(), endDate);
     }
 
     private String getPathFromClasspath(String path) throws Exception {


### PR DESCRIPTION
Fix previously added feature for relevantDates in 2c831c5867691c6d106c67adc493ceb5e6674fc1.

The relevantDates should be a list of objects, and a not a single object. Similar to locations and beacons.

Use the same structure as other lists.